### PR TITLE
feat: add gha and k8s manifests

### DIFF
--- a/.github/workflows/argocd-example.yml
+++ b/.github/workflows/argocd-example.yml
@@ -1,0 +1,77 @@
+name: ArgoCD Example
+
+on:
+  pull_request:
+    types:
+      - opened
+      - synchronize
+      - reopened
+  push:
+    branches:
+      - main
+      - prod
+
+env:
+  REGISTRY: ghcr.io
+
+jobs:
+  lint:
+    name: Lint
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: 'go.mod'
+          cache: false
+      - name: Golang CI Lint
+        uses: golangci/golangci-lint-action@v6
+        with:
+          version: v1.61
+          args: --timeout=10m --issues-exit-code=0
+  build:
+    needs: [lint]
+    name: Build
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{github.actor}}
+          password: ${{secrets.GITHUB_TOKEN}}
+      - name: Build and push application (commit)
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: Dockerfile
+          push: true
+          tags: |
+            ${{ env.REGISTRY }}/${{ github.repository }}:${{ github.sha }}
+      - name: Build and push application (latest)
+        if: github.ref == 'refs/heads/main' || github.ref == 'refs/heads/prod'
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: Dockerfile
+          push: true
+          tags: |
+            ${{ env.REGISTRY }}/${{ github.repository }}:latest
+      
+  do:
+    runs-on: ubuntu-latest
+    needs: [build]
+    if: github.ref == 'refs/heads/main' || github.ref == 'refs/heads/prod'
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+      - name: Update DO cluster
+        run: |
+          export DIGITALOCEAN_ACCESS_TOKEN="${{ secrets.DIGITALOCEAN_ACCESS_TOKEN }}"
+          make deploy

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,14 @@
+FROM golang:1.23.4 AS builder
+
+WORKDIR /app
+COPY go.* ./
+COPY . .
+RUN CGO_ENABLED=0 GOOS=linux go build -o /tmp/build/argocd-example ./cmd/api
+
+FROM gcr.io/distroless/static-debian12:nonroot
+
+COPY --from=builder /tmp/build/argocd-example /
+
+EXPOSE 8080
+
+CMD ["/argocd-example"]

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,2 @@
+deploy:
+	@bin/do

--- a/bin/do
+++ b/bin/do
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+set -e
+
+if ! [ -e /etc/tracker-tv-do.conf ]; then
+  if tty >/dev/null; then
+    export TTYOPTS=-it
+  else
+    export TTYOPTS=
+  fi
+
+  arch=$([ "$(arch)" = "x86_64" ] && echo "amd64" || echo "arm64")
+  docker run --rm $TTYOPTS -w /opt -v /var/run/docker.sock:/var/run/docker.sock -e DIGITALOCEAN_ACCESS_TOKEN -v $PWD:/opt ghcr.io/tracker-tv/do-$arch:latest bin/do
+
+  exit
+fi
+
+cluster_name=doks
+
+doctl kubernetes cluster kubeconfig save "$cluster_name"
+
+kubectl apply -f k8s/argocd/argocd.k8s.yml

--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -1,0 +1,37 @@
+package main
+
+import (
+	"encoding/json"
+	"net/http"
+)
+
+type Todo struct {
+	ID        int    `json:"id"`
+	Name      string `json:"name"`
+	Completed bool   `json:"completed"`
+}
+
+func main() {
+	mux := http.NewServeMux()
+
+	mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+		data := []Todo{
+			{1, "Test argocd deployment", false},
+			{2, "Create a new project", false},
+			{3, "Create a new project", false},
+		}
+		js, err := json.MarshalIndent(data, "", "\t")
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write(js)
+	})
+
+	if err := http.ListenAndServe(":8080", mux); err != nil {
+		return
+	}
+}

--- a/k8s/argocd/argocd.k8s.yml
+++ b/k8s/argocd/argocd.k8s.yml
@@ -1,0 +1,18 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: argocd-example
+  namespace: argocd
+spec:
+  destination:
+    namespace: default
+    server: https://kubernetes.default.svc
+  project: default
+  source:
+    path: k8s/manifests
+    repoURL: https://github.com/tracker-tv/argocd-example
+    targetRevision: HEAD
+  syncPolicy:
+    automated: {}
+    syncOptions:
+      - CreateNamespace=true

--- a/k8s/manifests/argocd-example.k8s.yml
+++ b/k8s/manifests/argocd-example.k8s.yml
@@ -1,0 +1,44 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: argocd-example
+  labels:
+    app: argocd-example
+spec:
+  selector:
+    app: argocd-example
+  ports:
+    - name: http
+      protocol: TCP
+      port: 8080
+      targetPort: 8080
+  type: ClusterIP
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: argocd-example
+  labels:
+    account: argocd-example
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: argocd-example
+  labels:
+    app: argocd-example
+spec:
+  replicas: 1
+  selector:
+      matchLabels:
+        app: argocd-example
+  template:
+      metadata:
+        labels:
+          app: argocd-example
+      spec:
+        containers:
+          - name: argocd-example
+            image: ghcr.io/tracker-tv/argocd-example:latest
+            ports:
+            - containerPort: 8080


### PR DESCRIPTION
This pull request introduces a comprehensive setup for deploying an ArgoCD example application, including the necessary configurations for GitHub Actions, Docker, Kubernetes, and a basic Go application. The most important changes include adding a GitHub Actions workflow, creating a Dockerfile, defining Kubernetes manifests, and implementing a simple Go application.

### GitHub Actions Workflow:
* Added a new GitHub Actions workflow file `.github/workflows/argocd-example.yml` to automate linting, building, and deploying the application.

### Docker:
* Created a `Dockerfile` to build and package the Go application using a multi-stage build process.

### Kubernetes Manifests:
* Added Kubernetes manifests in `k8s/manifests/argocd-example.k8s.yml` to define the service, service account, and deployment for the application.
* Added an ArgoCD application manifest in `k8s/argocd/argocd.k8s.yml` to manage the deployment.

### Go Application:
* Implemented a simple Go application in `cmd/api/main.go` that serves a list of TODO items via an HTTP endpoint.

### Makefile:
* Added a `deploy` target in the `Makefile` to facilitate deployment using a custom script.