### PR TITLE
fix: add execution permission

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,2 +1,3 @@
 deploy:
+	chmod +x bin/do
 	@bin/do


### PR DESCRIPTION
This pull request includes a small change to the `Makefile`. The change ensures that the script `bin/do` has execute permissions before it is run.

* `Makefile`: Added a command to set execute permissions on `bin/do` before running it.