### PR TITLE
feat: use commit sha for image tag

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 /.idea
+k8s/manifests/argocd-example.k8s.yml

--- a/bin/do
+++ b/bin/do
@@ -19,4 +19,9 @@ cluster_name=doks
 
 doctl kubernetes cluster kubeconfig save "$cluster_name"
 
-kubectl apply -f k8s/argocd/argocd.k8s.yml
+git_rev=$(git rev-parse HEAD)
+images="ghcr.io/tracker-tv/argocd-example:$git_rev"
+
+ytt --data-value images.argocd_example=$images -f k8s/argocd/argocd-example.k8s.yml > k8s/manifests/argocd-example.k8s.yml
+
+kubectl apply -f k8s/argocd/application.k8s.yml

--- a/k8s/argocd/application.k8s.yml
+++ b/k8s/argocd/application.k8s.yml
@@ -11,7 +11,7 @@ spec:
   source:
     path: k8s/manifests
     repoURL: https://github.com/tracker-tv/argocd-example
-    targetRevision: HEAD
+    targetRevision: main
   syncPolicy:
     automated: {}
     syncOptions:

--- a/k8s/argocd/argocd-example.k8s.yml
+++ b/k8s/argocd/argocd-example.k8s.yml
@@ -1,3 +1,4 @@
+#@ load("@ytt:data", "data")
 apiVersion: v1
 kind: Service
 metadata:
@@ -39,7 +40,8 @@ spec:
       spec:
         containers:
           - name: argocd-example
-            image: ghcr.io/tracker-tv/argocd-example:latest
+            image: #@ data.values.images.argocd_example
+            imagePullPolicy: "IfNotPresent"
             ports:
               - containerPort: 8080
             resources:


### PR DESCRIPTION
This pull request includes several changes to the Kubernetes configuration files to update image references and improve deployment practices. The most important changes include renaming files for better organization, updating the target revision for ArgoCD, and modifying image references to use dynamic values.

File renaming and organization:

* `k8s/argocd/application.k8s.yml`: Renamed from `k8s/argocd/argocd.k8s.yml` to better reflect its purpose.
* `k8s/argocd/argocd-example.k8s.yml`: Renamed from `k8s/manifests/argocd-example.k8s.yml` to improve file organization.

Configuration updates:

* `k8s/argocd/application.k8s.yml`: Updated `targetRevision` from `HEAD` to `main` for better alignment with branch naming conventions.
* `k8s/argocd/argocd-example.k8s.yml`: Added `imagePullPolicy: "IfNotPresent"` to ensure images are not pulled if already present, and updated the image reference to use dynamic values from `data.values.images.argocd_example`.